### PR TITLE
Remove unnecessary space

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,6 @@ module.exports = function(practitioner, opts = {}) {
 
   return {
     data,
-    ... createLine(data),
+    ...createLine(data),
   }
 };


### PR DESCRIPTION
# Fix Details
The whole `bundle.js` of `caremesh-frontend` won't load on the Edge browsers because `index.js` of this package is not getting properly compiled by Babel. I think, for some reason, Babel does not compile spread operators that come before space which triggers a runtime error on the ES6-noncompliant browsers like Edge.

Not 100% sure about what I said, but still worth to give it a try.